### PR TITLE
fix readme to reflect case sensitive file src

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Still under `config/app.php` add `'Sonus' => 'Closca\Sonus\Facade'` to the `$ali
 
 Run the `artisan` command below to publish the configuration file
 
-	$ php artisan config:publish Closca/Sonus
+	$ php artisan config:publish closca/sonus
 
 Navigate to `app/config/packages/Closca/Sonus/config.php` and update all four parameters
 


### PR DESCRIPTION
The change is necessary as in /vendor the user and package folder names are actually lowercase, on case sensitive filesystems this prevents following the readme from working without modifying the case manually.
