### PR TITLE
Require laravel/framework 5.1.1 to 5.1.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,6 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "laravel/framework": "5.1.1"
+        "laravel/framework": "5.1.*"
     }
 }


### PR DESCRIPTION
Not sure why it was locked to 5.1.1 but there is not 5.1.5 and higher available now.
